### PR TITLE
Trim whilst cleaning input values

### DIFF
--- a/src/feature.js
+++ b/src/feature.js
@@ -66,6 +66,7 @@ Feature = {
         function clean(value) {
             value = value.replace(/['"]/g, '');
             value = value.replace(/\W/g, ' ');
+            value = value.replace(/^\s|\s$/g, ''); 
 
             return value;
         }


### PR DESCRIPTION
Replacing non-alphanumeric characters with a space (L68) can create leading/trailing white space e.g. `[dev] sample task` which results in duplicate delimiter chars when the `key` & `summary` are concatenated.