### PR TITLE
Support for regex 'ignore' pattern

### DIFF
--- a/src/feature.js
+++ b/src/feature.js
@@ -5,7 +5,8 @@ Feature = {
         delimiter: "-",
         summaryCase: "lower",
         summaryDelimiter: "-",
-        maxLength: 100
+        maxLength: 100,
+        ignoredPattern: null
     },
 
     /**
@@ -23,10 +24,12 @@ Feature = {
             summary;
 
         index = source.indexOf(' ');
-        key = clean(source.slice(0, index));
+        key = ignore(source.slice(0, index), Feature.options.ignoredPattern);
+        key = clean(key);
         key = fixCase(key, Feature.options.keyCase, Feature.options.keyDelimiter);
 
-        summary = clean(source.slice(index + 1));
+        summary = ignore(source.slice(index + 1), Feature.options.ignoredPattern);
+        summary = clean(summary);
         summary = fixCase(summary, Feature.options.summaryCase, Feature.options.summaryDelimiter);
 
         if (key && summary) {
@@ -40,6 +43,16 @@ Feature = {
         }
 
         return result.slice(0, Feature.options.maxLength);
+        
+        function ignore(value, pattern) {
+
+            if(pattern != null && pattern != '') {
+                var regex = new RegExp(pattern, 'gi');
+                value = value.replace(regex, '');
+            }
+
+            return value;
+        }
 
         function fixCase(value, caseType, delimiter) {
             switch (caseType) {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
     "name": "Convert JIRA issue to feature name",
     "short_name": "JIRA Issue to Feature",
-    "version": "0.5.3",
+    "version": "0.5.4",
 
     "content_scripts": [{
        "matches": ["<all_urls>"],

--- a/src/options.css
+++ b/src/options.css
@@ -26,6 +26,7 @@ body {
 
 .value {
     display: inline-block;
+    max-width: 122px;
 }
 
 .wide {

--- a/src/options.html
+++ b/src/options.html
@@ -23,6 +23,10 @@
             <option value="/">Slash "/"</option>
         </select>
     </div>
+    <div class="property">
+        <label class="key" for="ignoredPattern">Ignored Pattern</label>
+        <input class="value" id="ignoredPattern" type="text" max="100" placeholder="Regex pattern to ignore">
+    </div>
 
     <div class="sectionHeader">Key</div>
     <div class="property">


### PR DESCRIPTION
Added support for a regex pattern to strip text from the jira task name. This is intended to strip out meta data often included in jira task names that is irrelevant to the branch naming.